### PR TITLE
Prefer install generator uses ApplicationRecord

### DIFF
--- a/lib/generators/madmin/install/install_generator.rb
+++ b/lib/generators/madmin/install/install_generator.rb
@@ -24,7 +24,11 @@ module Madmin
       def resources
         Rails.application.eager_load! unless Rails.application.config.cache_classes
 
-        ActiveRecord::Base.descendants.reject(&:abstract_class?)
+        if Object.const_defined?('ApplicationRecord')
+          return ApplicationRecord.descendants.reject(&:abstract_class?)
+        else
+          ActiveRecord::Base.descendants.reject(&:abstract_class?)
+        end
       end
     end
   end


### PR DESCRIPTION
Our Install Generator seems to not like it when it comes across models that inherit from ActiveRecord::Base, such as pg_search's PgDocument::Search model. 

This makes it so it prefers ApplicationRecord if one is defined. 